### PR TITLE
Remove devdax support

### DIFF
--- a/src/runtime/pmemMap.go
+++ b/src/runtime/pmemMap.go
@@ -8,10 +8,9 @@ import (
 )
 
 const (
-	fileCreate        = (1 << 0)
-	fileExcl          = (1 << 1)
-	fileAllFlags      = fileCreate | fileExcl
-	fileDaxValidFlags = fileCreate
+	fileCreate   = (1 << 0)
+	fileExcl     = (1 << 1)
+	fileAllFlags = fileCreate | fileExcl
 
 	// The valid file open modes that can be passed to the open system call are
 	// 0400, 0200, etc (see http://man7.org/linux/man-pages/man2/open.2.html).
@@ -62,25 +61,8 @@ func mapFile(path string, len, flags, mode int, off uintptr,
 
 	devDax := isFileDevDax(path)
 	if devDax {
-		if flags & ^fileDaxValidFlags != 0 {
-			println("Flag unsupported for Device DAX")
-			return
-		}
-		if off != 0 {
-			println("Offset not supported for Device DAX")
-			return
-		}
-		devSize := getFileSize(path)
-		if devSize < 0 {
-			println("Unable to get device DAX size")
-		}
-		if len != 0 && len != devSize {
-			println("Device DAX length must be either 0 or the exact size of the device")
-			return
-		}
-		len = devSize
-		// ignore all of the flags for devdax
-		flags = 0
+		println("Device DAX not supported")
+		return
 	} else {
 		if flags&fileCreate != 0 {
 			if len < 0 {

--- a/src/runtime/pmemUtil.go
+++ b/src/runtime/pmemUtil.go
@@ -15,7 +15,6 @@ const (
 	S_IFMT               = 0xf000
 	S_IFCHR              = 0x2000
 	PATH_MAX             = 256
-	MAX_SIZE_LENGTH      = 64
 )
 
 type timespec_t struct {
@@ -43,11 +42,16 @@ type stat_t struct {
 }
 
 var (
-	// sizebuf is used by utilDevDaxSize. runtime package cannot have local
-	// variables escape to the heap. Hence sizebuf is kept as a global buffer
-	// for file read operation.
-	sizebuf [MAX_SIZE_LENGTH]byte
+	// runtime package cannot have local variables escape to the heap. Hence
+	// pathBuf is kept as a global buffer for various APIs that need a byte
+	// array.
+	pathBuf [PATH_MAX]byte
 )
+
+// Most functions in this file are called as a result of a persistent memory
+// allocation request for the first time (through mallocgc). Therefore, those
+// functions must ensure that it does not create a memory allocation side-effect
+// as this will result in a malloc deadlock.
 
 // A utility function to map a persistent memory file in the address space.
 // This function first tries to map the file with MAP_SYNC flag. This succeeds
@@ -67,8 +71,9 @@ func utilMap(mapAddr unsafe.Pointer, fd int32, len, flags int, off uintptr,
 	p, err := mmap(mapAddr, uintptr(len), int32(protection),
 		int32(flags|_MAP_SHARED_VALIDATE|_MAP_SYNC), fd, off)
 	if err == 0 {
-		// Mapping with MAP_SYNC succeeded. Return the mapped address and a boolean
-		// value 'true' to indicate this file is indeed on a persistent memory device.
+		// Mapping with MAP_SYNC succeeded. Return the mapped address and a
+		// boolean value 'true' to indicate this file is indeed on a persistent
+		//  memory device.
 		return p, true, err
 	} else if err == _EOPNOTSUPP || err == _EINVAL {
 		p, err = mmap(mapAddr, uintptr(len), int32(protection), int32(flags), fd, off)
@@ -120,6 +125,7 @@ func minorNum(rdev uint64) uint {
 
 func utilIsFdDevDax(fd int32) bool {
 	var st stat_t
+	var mj, mn [8]byte
 	if fstat(uintptr(fd), uintptr(unsafe.Pointer(&st))) < 0 {
 		println("utilIsFdDevDax: Error fstat of file")
 		return false
@@ -139,49 +145,60 @@ func utilIsFdDevDax(fd int32) bool {
 	// a relative path to /sys/class/dax. It then verifies that the last 9
 	// characters equal 'class/dax'.
 	// See util_fd_is_device_dax() in https://github.com/pmem/pmdk/blob/master/src/common/file.c
+	mb := uintToBytes(majorNum(st.rdev), mj[:])
+	m2b := uintToBytes(minorNum(st.rdev), mn[:])
+	combineBytes(pathBuf[:], []byte("/sys/dev/char/"), mj[:mb], []byte(":"),
+		mn[:m2b], []byte("/subsystem"))
 
-	devPath := "/sys/dev/char/" + uintToString(majorNum(st.rdev)) + ":" +
-		uintToString(minorNum(st.rdev)) + "/subsystem"
-
-	resolvedPath := readLink(devPath)
-	if len(resolvedPath) < 9 {
-		return false
-	}
-	return resolvedPath[len(resolvedPath)-9:] == "class/dax"
+	return isClassDax(pathBuf[:])
 }
 
 // A helper function to get the size of a device dax
 func utilDevDaxSize(fd int32) int {
 	var st stat_t
+	var mj, mn [8]byte
+
 	if fstat(uintptr(fd), uintptr(unsafe.Pointer(&st))) < 0 {
 		println("utilDevDaxSize: Error fstat of file")
 		return -1
 	}
 
-	devSizePath := "/sys/dev/char/" + uintToString(majorNum(st.rdev)) + ":" +
-		uintToString(minorNum(st.rdev)) + "/size"
-	sizeArray := []byte(devSizePath)
-	sFd := open(&sizeArray[0], _O_RDONLY, 0)
+	mb := uintToBytes(majorNum(st.rdev), mj[:8])
+	m2b := uintToBytes(minorNum(st.rdev), mn[:8])
+	combineBytes(pathBuf[:], []byte("/sys/dev/char/"), mj[:mb], []byte(":"),
+		mn[:m2b], []byte("/size"))
+
+	sFd := open(&pathBuf[0], _O_RDONLY, 0)
 	if sFd < 0 {
 		println("Error opening device dax size file")
 		return -1
 	}
 
-	n := read(sFd, unsafe.Pointer(&sizebuf[0]), MAX_SIZE_LENGTH)
-	sz := stringToInt(string(sizebuf[:n]))
-
+	n := read(sFd, unsafe.Pointer(&pathBuf[0]), PATH_MAX)
+	sz := bytesToInt(pathBuf[:n])
 	return sz
+}
+
+// combineBytes appends all the contents in args array into the 'result' buffer,
+// and returns the number of bytes copied.
+func combineBytes(result []byte, args ...[]byte) int {
+	memclrNoHeapPointers(unsafe.Pointer(&result[0]), uintptr(len(result)))
+	ind := 0
+	for i := range args {
+		copy(result[ind:], args[i])
+		ind += len(args[i])
+	}
+	return ind
 }
 
 // readLink is a helper function to call the readlink system call. It casts the
 // arguments to the required datatype and invokes the system call.
-func readLink(path string) string {
+func isClassDax(path []byte) bool {
 	var b [PATH_MAX]byte
-	pathArray := []byte(path)
-	ret := readlink(uintptr(unsafe.Pointer(&pathArray[0])),
+	ret := readlink(uintptr(unsafe.Pointer(&path[0])),
 		uintptr(unsafe.Pointer(&b[0])), PATH_MAX)
 	if ret < 0 {
-		return "" // read link failed
+		return false // read link failed
 	}
 
 	// Find the length of the path to return. This is done by finding the first
@@ -192,12 +209,31 @@ func readLink(path string) string {
 			break
 		}
 	}
-	return string(b[:len])
+	if len < 9 {
+		return false
+	}
+
+	return compareBytes(b[len-9:len], []byte("class/dax"))
 }
 
-// A utility function to convert an unsigned integer number to a string.
-func uintToString(num uint) string {
-	var b [PATH_MAX]byte
+// A utility function that compares two byte arrays and checks if their contents
+// are the same.
+func compareBytes(b1 []byte, b2 []byte) bool {
+	if len(b1) != len(b2) {
+		return false
+	}
+	for i := range b1 {
+		if b1[i] != b2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// A utility function to convert an unsigned integer number to a byte array.
+// The result is written to array 'b' and the function returns the number of
+// bytes written.
+func uintToBytes(num uint, b []byte) int {
 	var ind int
 	for num > 0 {
 		r := num % 10
@@ -210,18 +246,18 @@ func uintToString(num uint) string {
 	for i, j := 0, ind-1; i < ind/2; i, j = i+1, j-1 {
 		b[i], b[j] = b[j], b[i]
 	}
-	return string(b[:ind])
+
+	return ind
 }
 
-// A helper function to convert a string to an int
-// This is a simple implementation and supports only positive decimal values
-func stringToInt(s string) int {
+// A helper function to convert a byte array to an int. This is a simple
+// implementation and supports only positive decimal values
+func bytesToInt(s []byte) int {
 	var n uint64
-	for i := 0; i < len(s); i++ {
-		d := s[i]
+	for _, b := range s {
 		// skip unrecognized characters
-		if '0' <= d && d <= '9' {
-			v := d - '0'
+		if 48 <= b && b <= 57 {
+			v := b - 48
 			n *= uint64(10)
 			n += uint64(v)
 		}


### PR DESCRIPTION
The current heap recovery mechanism used does not work on devdax devices
because devdax devices cannot be mmap'd in a per-arena basis. Instead
the entire size of the device should be mapped at once.
This commit removes support for devdax devices.
Most functions in pmemUtil.go are called from mallocgc when persistent
memory is requested for the first time by an application.  Hence this
commit also modifies those functions to ensure that it does not cause
further memory allocations as a side-effect which would result in a
malloc deadlock.
