### PR TITLE
Run GC in a new goroutine during initialization

### DIFF
--- a/src/runtime/pmemHeap.go
+++ b/src/runtime/pmemHeap.go
@@ -533,20 +533,14 @@ func SetRoot(addr unsafe.Pointer) (err error) {
 	return
 }
 
-// enableGC runs a full GC cycle as a stop-the-world event.
+// enableGC runs a full GC cycle in a new goroutine.
 // The argumnet gcp specifies garbage collection percentage and controls how
 // often GC is run (see https://golang.org/pkg/runtime/debug/#SetGCPercent).
 // Default value of gcp is 100.
 func enableGC(gcp int) {
 	setGCPercent(int32(gcp)) // restore GC percentage
 	// Run GC so that unused memory in reconstructed spans are reclaimed
-	stw := debug.gcstoptheworld
-	// set debug.gcstoptheworld as gcForceBlockMode so that GC runs as a
-	// stop-the-world event
-	debug.gcstoptheworld = int32(gcForceBlockMode)
-	GC()
-	// restore gcstoptheworld
-	debug.gcstoptheworld = stw
+	go GC()
 }
 
 // Restores the heap type bit information for the reconstructed span 's'.


### PR DESCRIPTION
This commit changes GC to be run in a new goroutine rather than as a stop the world (STW) event. This significantly speeds up the re-initialization function.

Earlier, GC was run as a stop-the-world event and initialization was declared to be complete only after the complete execution of GC. Now, initialization completes as soon as GC is started in a separate goroutine.

To compare impact of running garbage collection in a new goroutine vs as a STW event, I measured the memtier benchmark throughput in the two cases. The below graph shows the throughput while running memtier benchmark against Go Redis in two cases - (i) when GC is run in a new goroutine (ii) when GC is run as a STW event. The throughput of memtier benchmark is measured in kilo-operations per second. It is seen that, up to 700 milliseconds, the throughput in case (i) is pretty low. From 750 milliseconds onwards, the throughput picks up and is seen to be similar in the two cases.

![image](https://user-images.githubusercontent.com/883541/54303437-3642f900-4580-11e9-82b1-e2e6d62b53da.png)

### Memtier benchmark configuration
Num. clients = 10
Num threads = 10
Num. pipeline requests = 100
Num. requests = 1000000

### Initialization Time Comparison

Initialization time was compared in the two cases using Go Redis and memtier benchmark. About 2.6M Key value pairs were inserted into Go redis and the heap load time measured. The total database size was 1.28GB. More than 10x speedup was observed. No pointer swizzling was done in the two cases.

GC run as STW - 3.53 s
GC run in a new goroutine - 270.62 ms
