### PR TITLE
Changes to Go-compiler to use "txn" for using transactions

### DIFF
--- a/src/cmd/compile/internal/gc/builtin.go
+++ b/src/cmd/compile/internal/gc/builtin.go
@@ -150,12 +150,13 @@ var runtimeDecls = [...]struct {
 	{"racewriterange", funcTag, 112},
 	{"msanread", funcTag, 112},
 	{"msanwrite", funcTag, 112},
+	{"inpmem", funcTag, 113},
 	{"support_popcnt", varTag, 11},
 	{"support_sse41", varTag, 11},
 }
 
 func runtimeTypes() []*types.Type {
-	var typs [113]*types.Type
+	var typs [114]*types.Type
 	typs[0] = types.Bytetype
 	typs[1] = types.NewPtr(typs[0])
 	typs[2] = types.Types[TANY]
@@ -269,5 +270,6 @@ func runtimeTypes() []*types.Type {
 	typs[110] = functype(nil, []*Node{anonfield(typs[19]), anonfield(typs[19])}, []*Node{anonfield(typs[19])})
 	typs[111] = functype(nil, []*Node{anonfield(typs[47])}, nil)
 	typs[112] = functype(nil, []*Node{anonfield(typs[47]), anonfield(typs[47])}, nil)
+	typs[113] = functype(nil, []*Node{anonfield(typs[47])}, []*Node{anonfield(typs[11])})
 	return typs[:]
 }

--- a/src/cmd/compile/internal/gc/builtin.go
+++ b/src/cmd/compile/internal/gc/builtin.go
@@ -151,12 +151,14 @@ var runtimeDecls = [...]struct {
 	{"msanread", funcTag, 112},
 	{"msanwrite", funcTag, 112},
 	{"inpmem", funcTag, 113},
+	{"getTxHandle", funcTag, 114},
+	{"setTxHandle", funcTag, 115},
 	{"support_popcnt", varTag, 11},
 	{"support_sse41", varTag, 11},
 }
 
 func runtimeTypes() []*types.Type {
-	var typs [114]*types.Type
+	var typs [116]*types.Type
 	typs[0] = types.Bytetype
 	typs[1] = types.NewPtr(typs[0])
 	typs[2] = types.Types[TANY]
@@ -271,5 +273,7 @@ func runtimeTypes() []*types.Type {
 	typs[111] = functype(nil, []*Node{anonfield(typs[47])}, nil)
 	typs[112] = functype(nil, []*Node{anonfield(typs[47]), anonfield(typs[47])}, nil)
 	typs[113] = functype(nil, []*Node{anonfield(typs[47])}, []*Node{anonfield(typs[11])})
+	typs[114] = functype(nil, nil, []*Node{anonfield(typs[58])})
+	typs[115] = functype(nil, []*Node{anonfield(typs[58])}, nil)
 	return typs[:]
 }

--- a/src/cmd/compile/internal/gc/builtin/runtime.go
+++ b/src/cmd/compile/internal/gc/builtin/runtime.go
@@ -198,6 +198,10 @@ func msanwrite(addr, size uintptr)
 // inpmem check for ptr
 func inpmem(addr uintptr) bool
 
+// get, set for tx handle, maintained per goroutine
+func getTxHandle() unsafe.Pointer
+func setTxHandle(unsafe.Pointer)
+
 // architecture variants
 var support_popcnt bool
 var support_sse41 bool

--- a/src/cmd/compile/internal/gc/builtin/runtime.go
+++ b/src/cmd/compile/internal/gc/builtin/runtime.go
@@ -195,6 +195,9 @@ func racewriterange(addr, size uintptr)
 func msanread(addr, size uintptr)
 func msanwrite(addr, size uintptr)
 
+// inpmem check for ptr
+func inpmem(addr uintptr) bool
+
 // architecture variants
 var support_popcnt bool
 var support_sse41 bool

--- a/src/cmd/compile/internal/gc/esc.go
+++ b/src/cmd/compile/internal/gc/esc.go
@@ -910,6 +910,12 @@ opSwitch:
 	case OAS2: // x,y = a,b
 		if n.List.Len() == n.Rlist.Len() {
 			rs := n.Rlist.Slice()
+			if flag_txn && n.IsInjectedTxStmt() {
+				for i := range rs {
+					addrescapesFromTxn(n.List.Index(i), e, "used on lhs of assignment within txn() block")
+					addrescapesFromTxn(n.Rlist.Index(i), e, "used on rhs of assignment within txn() block")
+				}
+			}
 			where := n
 			for i, n := range n.List.Slice() {
 				e.escassignWhyWhere(n, rs[i], "assign-pair", where)

--- a/src/cmd/compile/internal/gc/go.go
+++ b/src/cmd/compile/internal/gc/go.go
@@ -217,6 +217,8 @@ var flag_race bool
 
 var flag_msan bool
 
+var flag_txn bool
+
 var flagDWARF bool
 
 // Whether we are adding any sort of code instrumentation, such as

--- a/src/cmd/compile/internal/gc/go.go
+++ b/src/cmd/compile/internal/gc/go.go
@@ -128,6 +128,12 @@ var racepkg *types.Pkg // package runtime/race
 
 var msanpkg *types.Pkg // package runtime/msan
 
+var txnpkg *types.Pkg // transaction package
+
+var txLogFn *Node // used in gc/ssa.go to read offset of Log() call in txn interface
+
+var txReadLogFn *Node // used in gc/ssa.go to read offset of ReadLog() call in txn interface
+
 var unsafepkg *types.Pkg // package unsafe
 
 var trackpkg *types.Pkg // fake package for field tracking

--- a/src/cmd/compile/internal/gc/go.go
+++ b/src/cmd/compile/internal/gc/go.go
@@ -135,6 +135,8 @@ var txBeginFn *Node    // used to read offset of Begin() method in tx interface
 var txEndFn *Node      // used to read offset of End() method in tx interface
 var txLogFn *Node      // used to read offset of Log() method in tx interface
 var txReadLogFn *Node  // used to read offset of ReadLog() method in tx interface
+var txLockFn *Node     // used to read offset of Lock() method in tx interface
+var txRLockFn *Node    // used to read offset of RLock() method in tx interface
 
 var unsafepkg *types.Pkg // package unsafe
 

--- a/src/cmd/compile/internal/gc/go.go
+++ b/src/cmd/compile/internal/gc/go.go
@@ -128,11 +128,13 @@ var racepkg *types.Pkg // package runtime/race
 
 var msanpkg *types.Pkg // package runtime/msan
 
-var txnpkg *types.Pkg // transaction package
-
-var txLogFn *Node // used in gc/ssa.go to read offset of Log() call in txn interface
-
-var txReadLogFn *Node // used in gc/ssa.go to read offset of ReadLog() call in txn interface
+// variables storing information of tx interface are used in gc/ssa.go during
+// buildssa. TODO: (mohitv) Find a better way.
+var txType *types.Type // used to read type of tx variable (transaction.TX)
+var txBeginFn *Node    // used to read offset of Begin() method in tx interface
+var txEndFn *Node      // used to read offset of End() method in tx interface
+var txLogFn *Node      // used to read offset of Log() method in tx interface
+var txReadLogFn *Node  // used to read offset of ReadLog() method in tx interface
 
 var unsafepkg *types.Pkg // package unsafe
 

--- a/src/cmd/compile/internal/gc/iimport.go
+++ b/src/cmd/compile/internal/gc/iimport.go
@@ -747,7 +747,7 @@ func (r *importReader) stmtList() []*Node {
 			break
 		}
 		// OBLOCK nodes may be created when importing ODCL nodes - unpack them
-		if n.Op == OBLOCK {
+		if n.Op == OBLOCK || n.Op == OTXBLOCK {
 			list = append(list, n.List.Slice()...)
 		} else {
 			list = append(list, n)
@@ -771,7 +771,7 @@ func (r *importReader) exprList() []*Node {
 
 func (r *importReader) expr() *Node {
 	n := r.node()
-	if n != nil && n.Op == OBLOCK {
+	if n != nil && (n.Op == OBLOCK || n.Op == OTXBLOCK) {
 		Fatalf("unexpected block node: %v", n)
 	}
 	return n

--- a/src/cmd/compile/internal/gc/inl.go
+++ b/src/cmd/compile/internal/gc/inl.go
@@ -582,7 +582,7 @@ func inlnode(n *Node, maxCost int32) *Node {
 
 	inlnodelist(n.List, maxCost)
 	switch n.Op {
-	case OBLOCK:
+	case OBLOCK, OTXBLOCK:
 		for _, n2 := range n.List.Slice() {
 			if n2.Op == OINLCALL {
 				inlconv2stmt(n2)

--- a/src/cmd/compile/internal/gc/main.go
+++ b/src/cmd/compile/internal/gc/main.go
@@ -251,6 +251,7 @@ func Main(archInit func(*Arch)) {
 	flag.StringVar(&blockprofile, "blockprofile", "", "write block profile to `file`")
 	flag.StringVar(&mutexprofile, "mutexprofile", "", "write mutex profile to `file`")
 	flag.StringVar(&benchfile, "bench", "", "append benchmark times to `file`")
+	flag.BoolVar(&flag_txn, "txn", false, "generate transaction logging code")
 	objabi.Flagparse(usage)
 
 	// Record flags that affect the build result. (And don't

--- a/src/cmd/compile/internal/gc/noder.go
+++ b/src/cmd/compile/internal/gc/noder.go
@@ -86,6 +86,10 @@ func (p *noder) makeSrcPosBase(b0 *syntax.PosBase) *src.PosBase {
 		fn := b0.Filename()
 		if b0.IsFileBase() {
 			b1 = src.NewFileBase(fn, absFilename(fn))
+		} else if b0 == nil {
+			// injected code by tx changes
+			fn = "transact.go" // assign temporary file name to injected stmts
+			b1 = src.NewFileBase(fn, absFilename(fn))
 		} else {
 			// line directive base
 			p0 := b0.Pos()

--- a/src/cmd/compile/internal/gc/noder.go
+++ b/src/cmd/compile/internal/gc/noder.go
@@ -48,7 +48,11 @@ func parseFiles(filenames []string) uint {
 			}
 			defer f.Close()
 
-			p.file, _ = syntax.Parse(base, f, p.error, p.pragma, syntax.CheckBranches) // errors are tracked via p.error
+			parserMode := syntax.CheckBranches
+			if flag_txn {
+				parserMode = parserMode | syntax.GenTxn
+			}
+			p.file, _ = syntax.Parse(base, f, p.error, p.pragma, parserMode) // errors are tracked via p.error
 		}(filename)
 	}
 

--- a/src/cmd/compile/internal/gc/noder.go
+++ b/src/cmd/compile/internal/gc/noder.go
@@ -1115,6 +1115,12 @@ func (p *noder) txBlockStmt(txB *syntax.TxBlockStmt) []*Node {
 	if txReadLogFn == nil {
 		txReadLogFn = p.getNewNodeFromString("tx.ReadLog(a)")
 	}
+	if txLockFn == nil {
+		txLockFn = p.getNewNodeFromString("tx.Lock(a)")
+	}
+	if txRLockFn == nil {
+		txRLockFn = p.getNewNodeFromString("tx.RLock(a)")
+	}
 	return nodes
 }
 

--- a/src/cmd/compile/internal/gc/noder.go
+++ b/src/cmd/compile/internal/gc/noder.go
@@ -1084,19 +1084,12 @@ func (p *noder) txBlockStmt(txB *syntax.TxBlockStmt) []*Node {
 	}
 	// mark tx.Begin() call to be recognized later during buildssa phase
 	nodes[len(nodes)-1].SetInjectedTxStmt(true)
+
 	p.openScope(txB.B.Pos())
-	for _, s := range txB.B.List {
-		if _, ok := s.(*syntax.AssignStmt); ok {
-			n := p.stmt(s)
-			n.SetInjectedTxStmt(true)
-			nodes = append(nodes, n)
-		} else {
-			sList := []syntax.Stmt{s}
-			n := p.stmts(sList)
-			nodes = append(nodes, n...)
-		}
-	}
+	txBody := p.stmts(txB.B.List)
 	p.closeScope(txB.B.Rbrace)
+	nodes = append(nodes, txliststmt(txBody))
+
 	nodes = append(nodes, p.stmts(txB.Post)...)
 	if txLogFn == nil || txReadLogFn == nil {
 		// Random function calls to populate transaction interface table

--- a/src/cmd/compile/internal/gc/noder.go
+++ b/src/cmd/compile/internal/gc/noder.go
@@ -92,7 +92,7 @@ func (p *noder) makeSrcPosBase(b0 *syntax.PosBase) *src.PosBase {
 			b1 = src.NewFileBase(fn, absFilename(fn))
 		} else if b0 == nil {
 			// injected code by tx changes
-			fn = "transact.go" // assign temporary file name to injected stmts
+			fn = "txn.go" // assign temporary file name to injected stmts
 			b1 = src.NewFileBase(fn, absFilename(fn))
 		} else {
 			// line directive base

--- a/src/cmd/compile/internal/gc/order.go
+++ b/src/cmd/compile/internal/gc/order.go
@@ -104,6 +104,9 @@ func (o *Order) newTemp(t *types.Type, clear bool) *Node {
 func (o *Order) copyExpr(n *Node, t *types.Type, clear bool) *Node {
 	v := o.newTemp(t, clear)
 	a := nod(OAS, v, n)
+	if flag_txn && n.IsInjectedTxReadLog() {
+		a.SetInjectedTxStmt(true)
+	}
 	a = typecheck(a, Etop)
 	o.out = append(o.out, a)
 	return v
@@ -557,12 +560,22 @@ func (o *Order) stmt(n *Node) {
 		o.out = append(o.out, n)
 
 	case OAS:
+		// Mark rhs node of assignment stmt so that all the intermediate
+		// OAS statements generated can be marked for tracking as well
+		if flag_txn && n.IsInjectedTxStmt() {
+			n.Right.SetInjectedTxReadLog(true)
+		}
 		t := o.markTemp()
 		n.Left = o.expr(n.Left, nil)
 		n.Right = o.expr(n.Right, n.Left)
 		o.mapAssign(n)
 		o.cleanTemp(t)
 
+		// reset flag on rhs node of assignment stmt which was set before.
+		// This will be marked correctly during buildssa in ssa.go
+		if flag_txn && n.IsInjectedTxStmt() {
+			n.Right.SetInjectedTxReadLog(false)
+		}
 	case OAS2,
 		OCLOSE,
 		OCOPY,

--- a/src/cmd/compile/internal/gc/ssa.go
+++ b/src/cmd/compile/internal/gc/ssa.go
@@ -4491,7 +4491,7 @@ func markNodeForTxReadLog(n *Node) {
 			markNodeForTxReadLog(high)
 		}
 		if max != nil {
-			panic(fmt.Sprintf("[ssa.go] compiler error. OSLICE/OSLICEARR/OSLICESTR",
+			panic(fmt.Sprintln("[ssa.go] compiler error. OSLICE/OSLICEARR/OSLICESTR",
 				"shouldn't have 3 args within []"))
 		}
 	case OADDR:
@@ -4499,7 +4499,7 @@ func markNodeForTxReadLog(n *Node) {
 		// Not reading this from log. If a call to ReadLog() is made, it would
 		// look something like tx.ReadLog(&&p) which would be a syntax error
 	default:
-		panic(fmt.Sprintf("[ssa.go] op %v", n.Op, "not supported on rhs of assignments within txn"))
+		panic(fmt.Sprintf("[ssa.go] op %v not supported on rhs of assignments within txn", n.Op))
 	}
 }
 

--- a/src/cmd/compile/internal/gc/ssa.go
+++ b/src/cmd/compile/internal/gc/ssa.go
@@ -4225,6 +4225,9 @@ func markNodeForTxLog(n *Node) {
 // Cases which set the InjectedTxReadLog flag of Node, need to be handled
 // explicitly in *state.expr method
 func markNodeForTxReadLog(n *Node) {
+	// TODO: (mohitv) Disable marking nodes for ReadLog instrumentation
+	// This would result in redo logging not working correctly
+	return
 	switch n.Op {
 	case OLITERAL, OSTRUCTLIT, OARRAYLIT, OSLICELIT:
 		// do nothing

--- a/src/cmd/compile/internal/gc/ssa.go
+++ b/src/cmd/compile/internal/gc/ssa.go
@@ -3769,6 +3769,55 @@ func (s *state) call(n *Node, k callKind) *ssa.Value {
 		}
 		if k == callNormal {
 			sym = fn.Sym
+			if flag_txn && s.inTxBlock {
+				if sym.Linksym() == Ctxt.Lookup("sync.(*RWMutex).Lock") || sym.Linksym() == Ctxt.Lookup("sync.(*RWMutex).RLock") {
+					var fnOffset int64
+					if sym.Linksym() == Ctxt.Lookup("sync.(*RWMutex).Lock") {
+						// replace m.Lock() with with tx.Lock(m)
+						txLock := typecheck(txLockFn.Left, Ecall)
+						fnOffset = txLock.Xoffset
+					} else {
+						txRLock := typecheck(txRLockFn.Left, Ecall)
+						fnOffset = txRLock.Xoffset
+					}
+					// Generate SSA for all temps first. This is done before
+					// function node or its args are converted to SSA
+					s.stmtList(n.List)
+
+					off := Ctxt.FixedFrameSize()
+					itab := s.newValue1(ssa.OpITab, types.Types[TUINTPTR], s.txIntf)
+					s.nilCheck(itab)
+					itabidx := fnOffset + 2*int64(Widthptr) + 8 // offset of fun field in runtime.itab
+					itab = s.newValue1I(ssa.OpOffPtr, s.f.Config.Types.UintptrPtr, itabidx, itab)
+					codeptr := s.load(types.Types[TUINTPTR], itab)
+					rcvr := s.newValue1(ssa.OpIData, types.Types[TUINTPTR], s.txIntf)
+
+					// Set receiver for interface calls
+					addr := s.constOffPtrSP(s.f.Config.Types.UintptrPtr, off)
+					s.store(types.Types[TUINTPTR], addr, rcvr)
+					off += types.Types[TUINTPTR].Size()
+
+					// obtain argument to the call from the receiver list of *gc.Node
+					t := n.Left.Type
+					args := n.Rlist.Slice()
+					f := t.Recv()
+
+					s.storeArg(args[0], f.Type, off+f.Offset)
+
+					off += f.Type.Size()
+					off = Rnd(off, int64(Widthreg))
+
+					call := s.newValue2(ssa.OpInterCall, types.TypeMem, codeptr, s.mem())
+					// Remember how much callee stack space we needed.
+					s.vars[&memVar] = call
+					call.AuxInt = off
+					return nil
+				}
+				if sym.Linksym() == Ctxt.Lookup("sync.(*RWMutex).Unlock") {
+					// Drop the unlock calls within txn() block
+					return nil
+				}
+			}
 			break
 		}
 		// Make a name n2 for the function.

--- a/src/cmd/compile/internal/gc/ssa.go
+++ b/src/cmd/compile/internal/gc/ssa.go
@@ -4415,10 +4415,8 @@ func (s *state) txnIntfCall(fnOffset int64, arg *ssa.Value) (*ssa.Value, int64) 
 	off += arg.Type.Size()
 
 	off = Rnd(off, int64(Widthreg))
-
 	call := s.newValue2(ssa.OpInterCall, types.TypeMem, codeptr, s.mem())
 	// Remember how much callee stack space we needed.
-	call.AuxInt = off
 	s.vars[&memVar] = call
 	return call, off
 }
@@ -4538,7 +4536,10 @@ func (s *state) txnLog(left, right *ssa.Value) []*ssa.Value {
 	// set up call to Log method of transaction interface
 	txLog := typecheck(txLogFn.Left, Ecall) // txLog = txn.Log, not the function call
 	fnOffset := txLog.Xoffset
-	s.txnIntfCall(fnOffset, arg)
+	dowidth(txLog.Type)
+	stksize := txLog.Type.ArgWidth()
+	call, _ := s.txnIntfCall(fnOffset, arg)
+	call.AuxInt = stksize
 	// Assumed no results
 	return nil
 }

--- a/src/cmd/compile/internal/gc/subr.go
+++ b/src/cmd/compile/internal/gc/subr.go
@@ -1751,6 +1751,16 @@ func listtreecopy(l []*Node, pos src.XPos) []*Node {
 	return out
 }
 
+// implementation taken from liststmt() function
+func txliststmt(l []*Node) *Node {
+	n := nod(OTXBLOCK, nil, nil)
+	n.List.Set(l)
+	if len(l) != 0 {
+		n.Pos = l[0].Pos
+	}
+	return n
+}
+
 func liststmt(l []*Node) *Node {
 	n := nod(OBLOCK, nil, nil)
 	n.List.Set(l)

--- a/src/cmd/compile/internal/gc/syntax.go
+++ b/src/cmd/compile/internal/gc/syntax.go
@@ -144,20 +144,22 @@ const (
 	_, nodeAssigned  // is the variable ever assigned to
 	_, nodeAddrtaken // address taken, even if not moved to heap
 	_, nodeImplicit
-	_, nodeIsddd     // is the argument variadic
-	_, nodeDiag      // already printed error about this
-	_, nodeColas     // OAS resulting from :=
-	_, nodeNonNil    // guaranteed to be non-nil
-	_, nodeNoescape  // func arguments do not escape; TODO(rsc): move Noescape to Func struct (see CL 7360)
-	_, nodeBounded   // bounds check unnecessary
-	_, nodeAddable   // addressable
-	_, nodeHasCall   // expression contains a function call
-	_, nodeLikely    // if statement condition likely
-	_, nodeHasVal    // node.E contains a Val
-	_, nodeHasOpt    // node.E contains an Opt
-	_, nodeEmbedded  // ODCLFIELD embedded type
-	_, nodeInlFormal // OPAUTO created by inliner, derived from callee formal
-	_, nodeInlLocal  // OPAUTO created by inliner, derived from callee local
+	_, nodeIsddd             // is the argument variadic
+	_, nodeDiag              // already printed error about this
+	_, nodeColas             // OAS resulting from :=
+	_, nodeNonNil            // guaranteed to be non-nil
+	_, nodeNoescape          // func arguments do not escape; TODO(rsc): move Noescape to Func struct (see CL 7360)
+	_, nodeBounded           // bounds check unnecessary
+	_, nodeAddable           // addressable
+	_, nodeHasCall           // expression contains a function call
+	_, nodeLikely            // if statement condition likely
+	_, nodeHasVal            // node.E contains a Val
+	_, nodeHasOpt            // node.E contains an Opt
+	_, nodeEmbedded          // ODCLFIELD embedded type
+	_, nodeInlFormal         // OPAUTO created by inliner, derived from callee formal
+	_, nodeInlLocal          // OPAUTO created by inliner, derived from callee local
+	_, nodeInjectedTxStmt    // Recognize if the node was injected in txn block. Used to track Begin(), Log() call
+	_, nodeInjectedTxReadLog // Recognize if the node was injected in txn block & is ReadLog() call
 )
 
 func (n *Node) Class() Class     { return Class(n.flags.get3(nodeClass)) }
@@ -186,6 +188,8 @@ func (n *Node) HasOpt() bool                { return n.flags&nodeHasOpt != 0 }
 func (n *Node) Embedded() bool              { return n.flags&nodeEmbedded != 0 }
 func (n *Node) InlFormal() bool             { return n.flags&nodeInlFormal != 0 }
 func (n *Node) InlLocal() bool              { return n.flags&nodeInlLocal != 0 }
+func (n *Node) IsInjectedTxStmt() bool      { return n.flags&nodeInjectedTxStmt != 0 }
+func (n *Node) IsInjectedTxReadLog() bool   { return n.flags&nodeInjectedTxReadLog != 0 }
 
 func (n *Node) SetClass(b Class)     { n.flags.set3(nodeClass, uint8(b)) }
 func (n *Node) SetWalkdef(b uint8)   { n.flags.set2(nodeWalkdef, b) }
@@ -213,6 +217,8 @@ func (n *Node) SetHasOpt(b bool)                { n.flags.set(nodeHasOpt, b) }
 func (n *Node) SetEmbedded(b bool)              { n.flags.set(nodeEmbedded, b) }
 func (n *Node) SetInlFormal(b bool)             { n.flags.set(nodeInlFormal, b) }
 func (n *Node) SetInlLocal(b bool)              { n.flags.set(nodeInlLocal, b) }
+func (n *Node) SetInjectedTxStmt(b bool)        { n.flags.set(nodeInjectedTxStmt, b) }
+func (n *Node) SetInjectedTxReadLog(b bool)     { n.flags.set(nodeInjectedTxReadLog, b) }
 
 // Val returns the Val for the node.
 func (n *Node) Val() Val {

--- a/src/cmd/compile/internal/gc/syntax.go
+++ b/src/cmd/compile/internal/gc/syntax.go
@@ -708,6 +708,7 @@ const (
 
 	// statements
 	OBLOCK    // { List } (block of code)
+	OTXBLOCK  // txn() { List } (block of code enclosed within txn() keyword)
 	OBREAK    // break [Sym]
 	OCASE     // case Left or List[0]..List[1]: Nbody (select case after processing; Left==nil and List==nil means default)
 	OXCASE    // case List: Nbody (select case before processing; List==nil means default)

--- a/src/cmd/compile/internal/gc/typecheck.go
+++ b/src/cmd/compile/internal/gc/typecheck.go
@@ -2145,7 +2145,9 @@ func typecheck1(n *Node, top int) (res *Node) {
 		}
 		typecheckslice(n.Nbody.Slice(), Etop)
 		decldepth--
-
+	case OTXBLOCK:
+		ok |= Etop
+		typecheckslice(n.List.Slice(), Etop)
 	case OIF:
 		ok |= Etop
 		typecheckslice(n.Ninit.Slice(), Etop)
@@ -4047,7 +4049,7 @@ func (n *Node) isterminating() bool {
 	// in the block handles the labeled statement case by
 	// skipping over the label. No case OLABEL here.
 
-	case OBLOCK:
+	case OBLOCK, OTXBLOCK:
 		return n.List.isterminating()
 
 	case OGOTO, ORETURN, ORETJMP, OPANIC, OFALL:

--- a/src/cmd/compile/internal/gc/typecheck.go
+++ b/src/cmd/compile/internal/gc/typecheck.go
@@ -115,6 +115,13 @@ func resolve(n *Node) (res *Node) {
 func typecheckslice(l []*Node, top int) {
 	for i := range l {
 		l[i] = typecheck(l[i], top)
+		// TODO: (mohitv) This is a hack to capture the type of transaction.TX
+		// interface. Find a better way
+		if flag_txn && l[i].IsInjectedTxStmt() && l[i].Op == OAS {
+			if l[i].Left != nil {
+				txType = l[i].Left.Type
+			}
+		}
 	}
 }
 

--- a/src/cmd/compile/internal/gc/walk.go
+++ b/src/cmd/compile/internal/gc/walk.go
@@ -211,7 +211,7 @@ func walkstmt(n *Node) *Node {
 			return walkstmt(nn)
 		}
 
-	case OBLOCK:
+	case OBLOCK, OTXBLOCK:
 		walkstmtlist(n.List.Slice())
 
 	case OXCASE:
@@ -719,12 +719,6 @@ opswitch:
 		walkexprlistsafe(n.Rlist.Slice(), init)
 		ll := ascompatee(OAS, n.List.Slice(), n.Rlist.Slice(), init)
 		ll = reorder3(ll)
-		if flag_txn && n.IsInjectedTxStmt() {
-			for _, s := range ll {
-				s.SetInjectedTxStmt(true)
-			}
-		}
-
 		n = liststmt(ll)
 
 	// a,b,... = fn()

--- a/src/cmd/compile/internal/gc/walk.go
+++ b/src/cmd/compile/internal/gc/walk.go
@@ -719,6 +719,12 @@ opswitch:
 		walkexprlistsafe(n.Rlist.Slice(), init)
 		ll := ascompatee(OAS, n.List.Slice(), n.Rlist.Slice(), init)
 		ll = reorder3(ll)
+		if flag_txn && n.IsInjectedTxStmt() {
+			for _, s := range ll {
+				s.SetInjectedTxStmt(true)
+			}
+		}
+
 		n = liststmt(ll)
 
 	// a,b,... = fn()

--- a/src/cmd/compile/internal/ssa/value.go
+++ b/src/cmd/compile/internal/ssa/value.go
@@ -54,7 +54,8 @@ type Value struct {
 	// nor a slot on Go stack, and the generation of this value is delayed to its use time.
 	OnWasmStack bool
 
-	WithinTx bool
+	StoreWithinTx bool
+	LoadWithinTx  bool
 
 	// Storage for the first three args
 	argstorage [3]*Value

--- a/src/cmd/compile/internal/ssa/value.go
+++ b/src/cmd/compile/internal/ssa/value.go
@@ -54,6 +54,8 @@ type Value struct {
 	// nor a slot on Go stack, and the generation of this value is delayed to its use time.
 	OnWasmStack bool
 
+	WithinTx bool
+
 	// Storage for the first three args
 	argstorage [3]*Value
 }

--- a/src/cmd/compile/internal/syntax/nodes.go
+++ b/src/cmd/compile/internal/syntax/nodes.go
@@ -340,7 +340,6 @@ type (
 		Pre    []Stmt
 		B      *BlockStmt
 		Logger LogMode
-		Post   []Stmt
 		stmt
 	}
 

--- a/src/cmd/compile/internal/syntax/nodes.go
+++ b/src/cmd/compile/internal/syntax/nodes.go
@@ -336,6 +336,14 @@ type (
 		stmt
 	}
 
+	TxBlockStmt struct {
+		Pre    []Stmt
+		B      *BlockStmt
+		Logger LogMode
+		Post   []Stmt
+		stmt
+	}
+
 	ExprStmt struct {
 		X Expr
 		simpleStmt

--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -2077,7 +2077,7 @@ func getVarNameFromLHS(e Expr) (s string) {
 func (p *parser) txBlock(declTx bool) []Stmt {
 	p.next()
 	p.want(_Lparen)
-	p.want(_Rparen) // Not expecting any argument in transact() use
+	p.want(_Rparen) // Not expecting any argument in txn() use
 	p.inTxBlock = true
 	var (
 		s     string
@@ -2184,8 +2184,8 @@ func (p *parser) stmtOrNil() Stmt {
 		p.next()
 		s.Label = p.name()
 		return s
-	case _Transact:
-		panic("parser.stmtorNil() don't know how to handle transact keyword")
+	case _Txn:
+		panic("parser.stmtorNil() don't know how to handle txn keyword")
 	case _Return:
 		s := new(ReturnStmt)
 		s.pos = p.pos()
@@ -2211,7 +2211,7 @@ func (p *parser) stmtList() (l []Stmt) {
 	}
 	firstTxKey := true
 	for p.tok != _EOF && p.tok != _Rbrace && p.tok != _Case && p.tok != _Default {
-		if p.tok == _Transact {
+		if p.tok == _Txn {
 			l = append(l, p.txBlock(firstTxKey)...)
 			firstTxKey = false
 		}

--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -975,9 +975,6 @@ loop:
 			p.xnest--
 
 		case _Lparen:
-			if p.inTxBlock {
-				p.syntaxError("go-pmem unexpected function call within transaction")
-			}
 			t := new(CallExpr)
 			t.pos = pos
 			t.Fun = x

--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -2092,11 +2092,6 @@ func (p *parser) txBlockStmt(declTx bool) *TxBlockStmt {
 	p.inTxBlock = true
 	t.B = p.blockStmt("txn block")
 	p.inTxBlock = false
-
-	s = "tx.End()"
-	t.Post = append(t.Post, ParseStmtFromScratch(s))
-	s = "transaction.Release(tx)"
-	t.Post = append(t.Post, ParseStmtFromScratch(s))
 	return t
 }
 

--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -2212,6 +2212,9 @@ func (p *parser) stmtList() (l []Stmt) {
 	firstTxKey := true
 	for p.tok != _EOF && p.tok != _Rbrace && p.tok != _Case && p.tok != _Default {
 		if p.tok == _Txn {
+			if p.mode&GenTxn == 0 {
+				p.syntaxError("txn() call not supported in this build mode, pass -txn while building")
+			}
 			l = append(l, p.txBlock(firstTxKey)...)
 			firstTxKey = false
 		}

--- a/src/cmd/compile/internal/syntax/scanner.go
+++ b/src/cmd/compile/internal/syntax/scanner.go
@@ -345,10 +345,10 @@ func (s *scanner) ident() {
 	s.ungetr()
 
 	lit := s.stopLit()
-
+	mapIndex, ok := keywordIndexInMap[string(lit)]
 	// possibly a keyword
-	if len(lit) >= 2 {
-		if tok := keywordMap[hash(lit)]; tok != 0 && tokStrFast(tok) == string(lit) {
+	if ok && len(lit) >= 2 {
+		if tok := keywordMap[mapIndex]; tok != 0 && tokStrFast(tok) == string(lit) {
 			s.nlsemi = contains(1<<_Break|1<<_Continue|1<<_Fallthrough|1<<_Return, tok)
 			s.tok = tok
 			return
@@ -389,15 +389,20 @@ func hash(s []byte) uint {
 }
 
 var keywordMap [1 << 6]token // size must be power of two
+var keywordIndexInMap map[string]int
 
 func init() {
+	var i int
+	keywordIndexInMap = make(map[string]int)
 	// populate keywordMap
 	for tok := _Break; tok <= _Var; tok++ {
-		h := hash([]byte(tok.String()))
-		if keywordMap[h] != 0 {
+		// h := hash([]byte(tok.String()))
+		if keywordMap[i] != 0 {
 			panic("imperfect hash")
 		}
-		keywordMap[h] = tok
+		keywordIndexInMap[tok.String()] = i
+		keywordMap[i] = tok
+		i++
 	}
 }
 

--- a/src/cmd/compile/internal/syntax/syntax.go
+++ b/src/cmd/compile/internal/syntax/syntax.go
@@ -16,6 +16,7 @@ type Mode uint
 // Modes supported by the parser.
 const (
 	CheckBranches Mode = 1 << iota // check correct use of labels, break, continue, and goto statements
+	GenTxn
 )
 
 // Error describes a syntax error. Error implements the error interface.

--- a/src/cmd/compile/internal/syntax/syntax.go
+++ b/src/cmd/compile/internal/syntax/syntax.go
@@ -19,6 +19,16 @@ const (
 	GenTxn
 )
 
+// LogMode describes the logging library to be used for injecting tx statements
+type LogMode uint
+
+const (
+	NulllLog = iota
+	UndoLog
+	RedoLog
+	CustomLog
+)
+
 // Error describes a syntax error. Error implements the error interface.
 type Error struct {
 	Pos Pos

--- a/src/cmd/compile/internal/syntax/syntax.go
+++ b/src/cmd/compile/internal/syntax/syntax.go
@@ -23,7 +23,7 @@ const (
 type LogMode uint
 
 const (
-	NulllLog = iota
+	NullLog = iota
 	UndoLog
 	RedoLog
 	CustomLog

--- a/src/cmd/compile/internal/syntax/token_string.go
+++ b/src/cmd/compile/internal/syntax/token_string.go
@@ -4,9 +4,9 @@ package syntax
 
 import "strconv"
 
-const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogotoifimportinterfacemappackagerangereturnselectstructswitchtypevar"
+const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogototransactifimportinterfacemappackagerangereturnselectstructswitchtypevar"
 
-var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 110, 116, 125, 128, 135, 140, 146, 152, 158, 164, 168, 171, 171}
+var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 116, 118, 124, 133, 136, 143, 148, 154, 160, 166, 172, 176, 179, 179}
 
 func (i token) String() string {
 	i -= 1

--- a/src/cmd/compile/internal/syntax/token_string.go
+++ b/src/cmd/compile/internal/syntax/token_string.go
@@ -4,9 +4,9 @@ package syntax
 
 import "strconv"
 
-const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogototransactifimportinterfacemappackagerangereturnselectstructswitchtypevar"
+const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogototxnifimportinterfacemappackagerangereturnselectstructswitchtypevar"
 
-var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 116, 118, 124, 133, 136, 143, 148, 154, 160, 166, 172, 176, 179, 179}
+var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 111, 113, 119, 128, 131, 138, 143, 149, 155, 161, 167, 171, 174, 174}
 
 func (i token) String() string {
 	i -= 1

--- a/src/cmd/compile/internal/syntax/tokens.go
+++ b/src/cmd/compile/internal/syntax/tokens.go
@@ -53,6 +53,7 @@ const (
 	_Func        // func
 	_Go          // go
 	_Goto        // goto
+	_Transact    // transact
 	_If          // if
 	_Import      // import
 	_Interface   // interface

--- a/src/cmd/compile/internal/syntax/tokens.go
+++ b/src/cmd/compile/internal/syntax/tokens.go
@@ -53,7 +53,7 @@ const (
 	_Func        // func
 	_Go          // go
 	_Goto        // goto
-	_Transact    // transact
+	_Txn         // txn
 	_If          // if
 	_Import      // import
 	_Interface   // interface

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -37,6 +37,7 @@ var (
 	BuildV                 bool // -v flag
 	BuildWork              bool // -work flag
 	BuildX                 bool // -x flag
+	BuildTxn               bool // -txn flag
 
 	CmdName string // "build", "install", "list", etc.
 

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -228,6 +228,7 @@ func AddBuildFlags(cmd *base.Command) {
 	cmd.Flag.StringVar(&cfg.BuildPkgdir, "pkgdir", "", "")
 	cmd.Flag.BoolVar(&cfg.BuildRace, "race", false, "")
 	cmd.Flag.BoolVar(&cfg.BuildMSan, "msan", false, "")
+	cmd.Flag.BoolVar(&cfg.BuildTxn, "txn", false, "generate code for transaction")
 	cmd.Flag.Var((*base.StringsFlag)(&cfg.BuildContext.BuildTags), "tags", "")
 	cmd.Flag.Var((*base.StringsFlag)(&cfg.BuildToolexec), "toolexec", "")
 	cmd.Flag.BoolVar(&cfg.BuildWork, "work", false, "")

--- a/src/cmd/go/internal/work/init.go
+++ b/src/cmd/go/internal/work/init.go
@@ -36,6 +36,11 @@ func BuildInit() {
 }
 
 func instrumentInit() {
+	if cfg.BuildTxn {
+		forcedGcflags = append(forcedGcflags, "-txn")
+		// TODO: This might be needed when auto-adding imports for transaction
+		//forcedLdflags = append(forcedLdflags, "-txn")
+	}
 	if !cfg.BuildRace && !cfg.BuildMSan {
 		return
 	}

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -508,6 +508,10 @@ var exprEnd = map[token.Token]bool{
 	token.RBRACE:    true,
 }
 
+var txnEnd = map[token.Token]bool{
+	token.RPAREN: true,
+}
+
 // safePos returns a valid file position for a given position: If pos
 // is valid to begin with, safePos returns pos. If pos is out-of-range,
 // safePos returns the EOF position.
@@ -2231,6 +2235,13 @@ func (p *parser) parseStmt() (s ast.Stmt) {
 	case token.BREAK, token.CONTINUE, token.GOTO, token.FALLTHROUGH:
 		s = p.parseBranchStmt(p.tok)
 	case token.LBRACE:
+		s = p.parseBlockStmt()
+		p.expectSemi()
+	case token.TXN:
+		p.next()
+		p.expect(token.LPAREN)
+		p.advance(txnEnd)
+		p.expect(token.RPAREN)
 		s = p.parseBlockStmt()
 		p.expectSemi()
 	case token.IF:

--- a/src/go/token/token.go
+++ b/src/go/token/token.go
@@ -108,6 +108,7 @@ const (
 	GOTO
 	IF
 	IMPORT
+	TXN
 
 	INTERFACE
 	MAP
@@ -209,6 +210,7 @@ var tokens = [...]string{
 	GOTO:   "goto",
 	IF:     "if",
 	IMPORT: "import",
+	TXN:    "txn",
 
 	INTERFACE: "interface",
 	MAP:       "map",

--- a/src/go/token/token.go
+++ b/src/go/token/token.go
@@ -108,7 +108,6 @@ const (
 	GOTO
 	IF
 	IMPORT
-	TXN
 
 	INTERFACE
 	MAP
@@ -121,6 +120,7 @@ const (
 	SWITCH
 	TYPE
 	VAR
+	TXN
 	keyword_end
 )
 

--- a/src/runtime/pmemHeap.go
+++ b/src/runtime/pmemHeap.go
@@ -499,8 +499,13 @@ func freeSpan(npages, base uintptr, needzero uint8, parena uintptr) {
 	h.freeSpanLocked(t, false, false, 0)
 }
 
-// InPmem checks whether 'addr' is an address in the persistent memory range
+// Public API
 func InPmem(addr uintptr) bool {
+	return inpmem(addr)
+}
+
+// InPmem checks whether 'addr' is an address in the persistent memory range
+func inpmem(addr uintptr) bool {
 	s := spanOfHeap(addr)
 	if s == nil {
 		return false

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -399,6 +399,17 @@ type g struct {
 	// and check for debt in the malloc hot path. The assist ratio
 	// determines how this corresponds to scan work debt.
 	gcAssistBytes int64
+
+	// tx handle
+	tx unsafe.Pointer
+}
+
+func getTxHandle() unsafe.Pointer {
+	return getg().tx
+}
+
+func setTxHandle(t unsafe.Pointer) {
+	getg().tx = t
 }
 
 type m struct {

--- a/src/runtime/sizeof_test.go
+++ b/src/runtime/sizeof_test.go
@@ -23,7 +23,7 @@ func TestSizeof(t *testing.T) {
 		_32bit uintptr     // size on 32bit platforms
 		_64bit uintptr     // size on 64bit platforms
 	}{
-		{runtime.G{}, 216, 376}, // g, but exported for testing
+		{runtime.G{}, 216, 384}, // g, but exported for testing
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Includes all the changes to-date (including the ability to use sync.(*RWMutex).Lock & Unlock & carry transactions across function calls).
All changes are fully functional only for undo transactions.
The changes have some TODOs marked with TODO: (mohitv) which I plan to improve as we progress.