### PR TITLE
Add -txn flag to go build

### DIFF
--- a/src/cmd/compile/internal/gc/go.go
+++ b/src/cmd/compile/internal/gc/go.go
@@ -217,6 +217,8 @@ var flag_race bool
 
 var flag_msan bool
 
+var flag_txn bool
+
 var flagDWARF bool
 
 // Whether we are adding any sort of code instrumentation, such as

--- a/src/cmd/compile/internal/gc/main.go
+++ b/src/cmd/compile/internal/gc/main.go
@@ -251,6 +251,7 @@ func Main(archInit func(*Arch)) {
 	flag.StringVar(&blockprofile, "blockprofile", "", "write block profile to `file`")
 	flag.StringVar(&mutexprofile, "mutexprofile", "", "write mutex profile to `file`")
 	flag.StringVar(&benchfile, "bench", "", "append benchmark times to `file`")
+	flag.BoolVar(&flag_txn, "txn", false, "generate transaction logging code")
 	objabi.Flagparse(usage)
 
 	// Record flags that affect the build result. (And don't

--- a/src/cmd/go/alldocs.go
+++ b/src/cmd/go/alldocs.go
@@ -113,6 +113,11 @@
 // 		enable interoperation with memory sanitizer.
 // 		Supported only on linux/amd64, linux/arm64
 // 		and only with Clang/LLVM as the host C compiler.
+// 	-txn
+// 		this flag enables the use of "txn" keyword. If this flag is not specified
+// 		during go build, use of "txn" keyword fails during compilation.
+// 		enable injection of transaction logging statements for stores within txn() {}.
+// 		Works with import of "github.com/vmware/go-pmem-transaction/transaction.
 // 	-v
 // 		print the names of packages as they are compiled.
 // 	-work

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -37,6 +37,7 @@ var (
 	BuildV                 bool // -v flag
 	BuildWork              bool // -work flag
 	BuildX                 bool // -x flag
+	BuildTxn               bool // -txn flag
 
 	CmdName string // "build", "install", "list", etc.
 

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -68,6 +68,11 @@ and test commands:
 		enable interoperation with memory sanitizer.
 		Supported only on linux/amd64, linux/arm64
 		and only with Clang/LLVM as the host C compiler.
+	-txn
+		this flag enables the use of "txn" keyword. If this flag is not specified
+		during go build, use of "txn" keyword fails during compilation.
+		enable injection of transaction logging statements for stores within txn() {}.
+		Works with import of "github.com/vmware/go-pmem-transaction/transaction.
 	-v
 		print the names of packages as they are compiled.
 	-work

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -228,6 +228,7 @@ func AddBuildFlags(cmd *base.Command) {
 	cmd.Flag.StringVar(&cfg.BuildPkgdir, "pkgdir", "", "")
 	cmd.Flag.BoolVar(&cfg.BuildRace, "race", false, "")
 	cmd.Flag.BoolVar(&cfg.BuildMSan, "msan", false, "")
+	cmd.Flag.BoolVar(&cfg.BuildTxn, "txn", false, "generate code for transaction")
 	cmd.Flag.Var((*base.StringsFlag)(&cfg.BuildContext.BuildTags), "tags", "")
 	cmd.Flag.Var((*base.StringsFlag)(&cfg.BuildToolexec), "toolexec", "")
 	cmd.Flag.BoolVar(&cfg.BuildWork, "work", false, "")

--- a/src/cmd/go/internal/work/init.go
+++ b/src/cmd/go/internal/work/init.go
@@ -36,6 +36,9 @@ func BuildInit() {
 }
 
 func instrumentInit() {
+	if cfg.BuildTxn {
+		forcedGcflags = append(forcedGcflags, "-txn")
+	}
 	if !cfg.BuildRace && !cfg.BuildMSan {
 		return
 	}


### PR DESCRIPTION
This change adds a new go build flag called "txn". This flag is
read by compiler and will be used to protect normal compiler path
from future transaction related changes.
The changes are similar to how compiler reads msan/race build
flags.

Example use: go build -txn
Testing: I ran go build with an unrecognized flag & with "-txn" & see expected outputs.
I also ran "all.bash" with -txn flag passed to all tests. Everything passes.