### PR TITLE
Add a new "txn" keyword & start using it with no functionality

### DIFF
--- a/src/cmd/compile/internal/gc/noder.go
+++ b/src/cmd/compile/internal/gc/noder.go
@@ -48,7 +48,11 @@ func parseFiles(filenames []string) uint {
 			}
 			defer f.Close()
 
-			p.file, _ = syntax.Parse(base, f, p.error, p.pragma, syntax.CheckBranches) // errors are tracked via p.error
+			parserMode := syntax.CheckBranches
+			if flag_txn {
+				parserMode = parserMode | syntax.GenTxn
+			}
+			p.file, _ = syntax.Parse(base, f, p.error, p.pragma, parserMode) // errors are tracked via p.error
 		}(filename)
 	}
 

--- a/src/cmd/compile/internal/gc/noder.go
+++ b/src/cmd/compile/internal/gc/noder.go
@@ -1072,8 +1072,7 @@ func (p *noder) blockStmt(stmt *syntax.BlockStmt) []*Node {
 }
 
 func (p *noder) txBlockStmt(txB *syntax.TxBlockStmt) []*Node {
-	var nodes []*Node
-	nodes = append(nodes, p.stmts(txB.Pre)...)
+	nodes := p.stmts(txB.Pre)
 	p.openScope(txB.B.Pos())
 	txBody := p.stmts(txB.B.List)
 	p.closeScope(txB.B.Rbrace)

--- a/src/cmd/compile/internal/gc/noder.go
+++ b/src/cmd/compile/internal/gc/noder.go
@@ -898,6 +898,12 @@ func (p *noder) stmtFall(stmt syntax.Stmt, fallOK bool) *Node {
 			return nod(OEMPTY, nil, nil)
 		}
 		return liststmt(l)
+	case *syntax.TxBlockStmt:
+		l := p.txBlockStmt(stmt)
+		if len(l) == 0 {
+			panic("go-pmem noder.stmtFall(): txBlock can never have zero nodes")
+		}
+		return liststmt(l)
 	case *syntax.ExprStmt:
 		return p.wrapname(stmt, p.expr(stmt.X))
 	case *syntax.SendStmt:
@@ -1058,6 +1064,16 @@ func (p *noder) blockStmt(stmt *syntax.BlockStmt) []*Node {
 	p.openScope(stmt.Pos())
 	nodes := p.stmts(stmt.List)
 	p.closeScope(stmt.Rbrace)
+	return nodes
+}
+
+func (p *noder) txBlockStmt(txB *syntax.TxBlockStmt) []*Node {
+	var nodes []*Node
+	nodes = append(nodes, p.stmts(txB.Pre)...)
+	p.openScope(txB.B.Pos())
+	txBody := p.stmts(txB.B.List)
+	p.closeScope(txB.B.Rbrace)
+	nodes = append(nodes, txBody...)
 	return nodes
 }
 

--- a/src/cmd/compile/internal/syntax/nodes.go
+++ b/src/cmd/compile/internal/syntax/nodes.go
@@ -336,6 +336,12 @@ type (
 		stmt
 	}
 
+	TxBlockStmt struct {
+		Pre []Stmt
+		B   *BlockStmt
+		stmt
+	}
+
 	ExprStmt struct {
 		X Expr
 		simpleStmt

--- a/src/cmd/compile/internal/syntax/nodes_test.go
+++ b/src/cmd/compile/internal/syntax/nodes_test.go
@@ -153,6 +153,8 @@ var stmts = []test{
 
 	{"BlockStmt", `@{}`},
 
+	{"TxBlockStmt", `@txn(){}`},
+
 	// The position of an ExprStmt is the position of the expression.
 	{"ExprStmt", `@<-ch`},
 	{"ExprStmt", `f@()`},
@@ -292,6 +294,16 @@ func testPos(t *testing.T, list []test, prefix, suffix string, extract func(*Fil
 
 		// build syntax tree
 		file, err := Parse(nil, strings.NewReader(src), nil, nil, 0)
+
+		if test.nodetyp == "TxBlockStmt" && err == nil {
+			t.Errorf("should have parse error because txn(){} cannot be parsed without additional flag: %s: %v (%s)",
+				src, err, test.nodetyp)
+			continue
+		} else if test.nodetyp == "TxBlockStmt" && err != nil {
+			// Parse again, with the correct parse mode for TxBlockStmt
+			file, err = Parse(nil, strings.NewReader(src), nil, nil, GenTxn)
+		}
+
 		if err != nil {
 			t.Errorf("parse error: %s: %v (%s)", src, err, test.nodetyp)
 			continue

--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -2176,6 +2176,9 @@ func (p *parser) stmtList() (l []Stmt) {
 	firstTxKey := true
 	for p.tok != _EOF && p.tok != _Rbrace && p.tok != _Case && p.tok != _Default {
 		if p.tok == _Txn {
+			if p.mode&GenTxn == 0 {
+				p.syntaxError("txn() use not supported. Add -txn flag while building")
+			}
 			l = append(l, p.txBlockStmt(firstTxKey))
 			// Next time we see txn() in the same code block (demarcated by {}),
 			// a new transaction variable will not be declared

--- a/src/cmd/compile/internal/syntax/parser.go
+++ b/src/cmd/compile/internal/syntax/parser.go
@@ -2031,9 +2031,10 @@ func ParseStmtFromScratch(s string) Stmt {
 	return f.DeclList[0].(*FuncDecl).Body.List[0]
 }
 
-// This function adds two statements to the application code:
-// 1. var tx transaction.NewUndoTx() <- It is made sure that tx is declared once
-// 2. tx.Begin() <- always inserted
+// This function adds three statements to the application code:
+// 1. var __tx transaction.TX <- It is made sure that __tx is declared once
+// 2. __tx = transaction.NewUndoTx() <- always inserted
+// 3. __tx.Begin() <- always inserted
 // Other statements to Log data, End the transaction & release the transaction
 // handle will be inserted to application code at a later compilation stage.
 // These statements are inserted by parser so that context, typesystem info for
@@ -2048,12 +2049,12 @@ func (p *parser) txBlockStmt(declTx bool) *TxBlockStmt {
 
 	var s string
 	if declTx {
-		s = "var tx transaction.TX"
+		s = "var __tx transaction.TX"
 		sList = append(sList, ParseStmtFromScratch(s))
 	}
-	s = "tx = transaction.NewUndoTx()"
+	s = "__tx = transaction.NewUndoTx()"
 	sList = append(sList, ParseStmtFromScratch(s))
-	s = "tx.Begin()"
+	s = "__tx.Begin()"
 	sList = append(sList, ParseStmtFromScratch(s))
 	t.Pre = sList
 	t.B = p.blockStmt("txn block")

--- a/src/cmd/compile/internal/syntax/parser_test.go
+++ b/src/cmd/compile/internal/syntax/parser_test.go
@@ -328,3 +328,71 @@ func TestLineDirectives(t *testing.T) {
 		}
 	}
 }
+
+func TestParseFileWithTxn(t *testing.T) {
+	src := "package p; func _() { txn(){} txn(){} }"
+
+	// For 1st txn(), check only 3 statements are inserted
+	wantNumStms := 3
+	f, err := Parse(NewFileBase(""), strings.NewReader(src), nil, nil, GenTxn)
+	if err != nil {
+		t.Errorf("parse error: %s: %v", src, err)
+	}
+	txB := f.DeclList[0].(*FuncDecl).Body.List[0].(*TxBlockStmt)
+	if len(txB.Pre) != wantNumStms {
+		t.Errorf("parser code injection error for txn(){}, injected %v stms instead of %v stms",
+			len(txB.Pre), wantNumStms)
+	}
+	// Code within {} should be left unmodified
+	if len(txB.B.List) != 0 {
+		t.Errorf("parser code injection error for txn(){}, injected %v stms instead of 0 stms",
+			len(txB.B.List))
+	}
+	// Check 1st statement injected is "var __tx transaction.TX"
+	s0 := txB.Pre[0]
+	decl := s0.(*DeclStmt).DeclList[0].(*VarDecl)
+	if decl.NameList[0].Value != "__tx" {
+		t.Errorf("parser code injection error for txn(){}, variable name want: __tx, got: %v",
+			decl.NameList[0].Value)
+	}
+	declType := decl.Type.(*SelectorExpr).X.(*Name).Value + "." + decl.Type.(*SelectorExpr).Sel.Value
+	if declType != "transaction.TX" {
+		t.Errorf("parser code injection error for txn(){}, variable type want: transaction.TX, got: %v",
+			declType)
+	}
+
+	checkTwoStmts := func(a, b Stmt) {
+		// check a should be "__tx = transaction.NewUndoTx"
+		aFn := a.(*AssignStmt).Rhs.(*CallExpr).Fun.(*SelectorExpr)
+		aFnName := aFn.X.(*Name).Value + "." + aFn.Sel.Value
+		if aFnName != "transaction.NewUndoTx" {
+			t.Errorf("parser code injection error for txn(){}, function name want: transaction.NewUndoTx, got: %v",
+				aFnName)
+		}
+
+		// check b should be "__tx.Begin"
+		bFn := b.(*ExprStmt).X.(*CallExpr).Fun.(*SelectorExpr)
+		bFnName := bFn.X.(*Name).Value + "." + bFn.Sel.Value
+		if bFnName != "__tx.Begin" {
+			t.Errorf("parser code injection error for txn(){}, function name want: __tx.Begin, got: %v",
+				bFnName)
+		}
+	}
+
+	// check next two statements
+	checkTwoStmts(txB.Pre[1], txB.Pre[2])
+
+	// For 2nd txn(), check only 2 statements are inserted
+	wantNumStms = 2
+	txB = f.DeclList[0].(*FuncDecl).Body.List[1].(*TxBlockStmt)
+	if len(txB.Pre) != wantNumStms {
+		t.Errorf("parser code injection error for txn(){}, injected %v stms instead of %v stms",
+			len(txB.Pre), wantNumStms)
+	}
+	// Code within {} should be left unmodified
+	if len(txB.B.List) != 0 {
+		t.Errorf("parser code injection error for txn(){}, injected %v stms instead of 0 stms",
+			len(txB.B.List))
+	}
+	checkTwoStmts(txB.Pre[0], txB.Pre[1])
+}

--- a/src/cmd/compile/internal/syntax/scanner_test.go
+++ b/src/cmd/compile/internal/syntax/scanner_test.go
@@ -260,6 +260,7 @@ var sampleTokens = [...]struct {
 	{_Struct, "struct", 0, 0},
 	{_Switch, "switch", 0, 0},
 	{_Type, "type", 0, 0},
+	{_Txn, "txn", 0, 0},
 	{_Var, "var", 0, 0},
 }
 

--- a/src/cmd/compile/internal/syntax/syntax.go
+++ b/src/cmd/compile/internal/syntax/syntax.go
@@ -16,6 +16,7 @@ type Mode uint
 // Modes supported by the parser.
 const (
 	CheckBranches Mode = 1 << iota // check correct use of labels, break, continue, and goto statements
+	GenTxn
 )
 
 // Error describes a syntax error. Error implements the error interface.

--- a/src/cmd/compile/internal/syntax/token_string.go
+++ b/src/cmd/compile/internal/syntax/token_string.go
@@ -4,9 +4,9 @@ package syntax
 
 import "strconv"
 
-const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogotoifimportinterfacemappackagerangereturnselectstructswitchtypetxnvar"
+const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogotoifimportinterfacemappackagerangereturnselectstructswitchtxntypevar"
 
-var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 110, 116, 125, 128, 135, 140, 146, 152, 158, 164, 168, 171, 174, 174}
+var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 110, 116, 125, 128, 135, 140, 146, 152, 158, 164, 167, 171, 174, 174}
 
 func (i token) String() string {
 	i -= 1

--- a/src/cmd/compile/internal/syntax/token_string.go
+++ b/src/cmd/compile/internal/syntax/token_string.go
@@ -4,9 +4,9 @@ package syntax
 
 import "strconv"
 
-const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogototxnifimportinterfacemappackagerangereturnselectstructswitchtypevar"
+const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogotoifimportinterfacemappackagerangereturnselectstructswitchtypetxnvar"
 
-var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 111, 113, 119, 128, 131, 138, 143, 149, 155, 161, 167, 171, 174, 174}
+var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 110, 116, 125, 128, 135, 140, 146, 152, 158, 164, 168, 171, 174, 174}
 
 func (i token) String() string {
 	i -= 1

--- a/src/cmd/compile/internal/syntax/token_string.go
+++ b/src/cmd/compile/internal/syntax/token_string.go
@@ -4,9 +4,9 @@ package syntax
 
 import "strconv"
 
-const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogotoifimportinterfacemappackagerangereturnselectstructswitchtypevar"
+const _token_name = "EOFnameliteralopop=opop=:=<-*([{)]},;:....breakcasechanconstcontinuedefaultdeferelsefallthroughforfuncgogototxnifimportinterfacemappackagerangereturnselectstructswitchtypevar"
 
-var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 110, 116, 125, 128, 135, 140, 146, 152, 158, 164, 168, 171, 171}
+var _token_index = [...]uint8{0, 3, 7, 14, 16, 19, 23, 24, 26, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 42, 47, 51, 55, 60, 68, 75, 80, 84, 95, 98, 102, 104, 108, 111, 113, 119, 128, 131, 138, 143, 149, 155, 161, 167, 171, 174, 174}
 
 func (i token) String() string {
 	i -= 1

--- a/src/cmd/compile/internal/syntax/tokens.go
+++ b/src/cmd/compile/internal/syntax/tokens.go
@@ -53,7 +53,6 @@ const (
 	_Func        // func
 	_Go          // go
 	_Goto        // goto
-	_Txn         // txn
 	_If          // if
 	_Import      // import
 	_Interface   // interface
@@ -65,6 +64,7 @@ const (
 	_Struct      // struct
 	_Switch      // switch
 	_Type        // type
+	_Txn         // txn
 	_Var         // var
 
 	// empty line comment to exclude it from .String

--- a/src/cmd/compile/internal/syntax/tokens.go
+++ b/src/cmd/compile/internal/syntax/tokens.go
@@ -53,6 +53,7 @@ const (
 	_Func        // func
 	_Go          // go
 	_Goto        // goto
+	_Txn         // txn
 	_If          // if
 	_Import      // import
 	_Interface   // interface

--- a/src/cmd/compile/internal/syntax/tokens.go
+++ b/src/cmd/compile/internal/syntax/tokens.go
@@ -63,8 +63,8 @@ const (
 	_Select      // select
 	_Struct      // struct
 	_Switch      // switch
-	_Type        // type
 	_Txn         // txn
+	_Type        // type
 	_Var         // var
 
 	// empty line comment to exclude it from .String


### PR DESCRIPTION
This change adds a new Go keyword called "txn", which can be used as:
```
txn() {
 // any code
}
```
The parser/AST creator will identify this keyword & inject some statements to initialize transaction variables & begin a transaction. 
There is no other functionality yet. All the code within txn() {} will execute as they should.

To build code using txn keyword: `go build -txn`

If you use only `go build` & have txn keyword in your code, 
you get a syntax error _"syntax error: txn() use not supported. Add -txn flag while building"_

Testing: all.bash with & without -txn flag

And a simple code like this works as intended:
```
import (
	"github.com/vmware/go-pmem-transaction/pmem"
	"github.com/vmware/go-pmem-transaction/transaction"
	"fmt"
	"os"
)

func main() {
	os.Remove("testFile")
	pmem.Init("testFile")
	var a int
	txn() {
		a = 2
		fmt.Println(a)
	}

	txn() {
		b := 3
		fmt.Println(b)
	}
}
```
