### PR TITLE
Change all.bash to run tests again with -txn flag

### DIFF
--- a/src/all.bash
+++ b/src/all.bash
@@ -11,5 +11,10 @@ fi
 OLDPATH="$PATH"
 . ./make.bash "$@" --no-banner
 bash run.bash --no-rebuild
+echo 'Running tests again with -txn flag'
+bash clean.bash
+export GO_GCFLAGS=$GO_GCFLAGS" -txn"
+. ./make.bash "$@" --no-banner
+bash run.bash --no-rebuild
 PATH="$OLDPATH"
 $GOTOOLDIR/dist banner  # print build info


### PR DESCRIPTION
**ONLY** change all.bash to enable testing with -txn flag. Includes fix to do clean.bash, so Travis will not reuse cached test data. Also adds to the GO_GCFLAGS instead of just writing to it.