### PR TITLE
Remove redundant error typecast from pmem functions - simple fix

### DIFF
--- a/src/runtime/pmemHeap.go
+++ b/src/runtime/pmemHeap.go
@@ -149,13 +149,13 @@ var pmemInfo struct {
 // medium.
 func PmemInit(fname string) (unsafe.Pointer, error) {
 	if GOOS != "linux" || GOARCH != "amd64" {
-		return nil, error(errorString("Unsupported architecture"))
+		return nil, errorString("Unsupported architecture")
 	}
 
 	// Change persistent memory initialization state from not-done to ongoing
 	if !atomic.Cas(&pmemInfo.initState, initNotDone, initOngoing) {
-		return nil, error(errorString(`Persistent memory is already initialized
-				or initialization is ongoing`))
+		return nil, errorString(`Persistent memory is already initialized
+				or initialization is ongoing`)
 	}
 
 	// Set the persistent memory file name. This will be used to map the file
@@ -167,7 +167,7 @@ func PmemInit(fname string) (unsafe.Pointer, error) {
 	mapAddr, isPmem, err := mapFile(fname, int(pmemHeaderSize), fileCreate,
 		_DEFAULT_FMODE, 0, nil)
 	if err != 0 {
-		return nil, error(errorString("Mapping persistent memory file failed"))
+		return nil, errorString("Mapping persistent memory file failed")
 	}
 	pmemHeader = (*pHeader)(mapAddr)
 	pmemInfo.isPmem = isPmem
@@ -252,7 +252,7 @@ func mapArenas() error {
 			fileCreate, _DEFAULT_FMODE, mapped, nil)
 		if err != 0 {
 			unmapArenas(arenas)
-			return error(errorString("Arena mapping failed"))
+			return errorString("Arena mapping failed")
 		}
 
 		// Point at the arena header
@@ -271,7 +271,7 @@ func mapArenas() error {
 				_DEFAULT_FMODE, mapped, nil)
 			if err != 0 {
 				unmapArenas(arenas)
-				return error(errorString("Arena mapping failed"))
+				return errorString("Arena mapping failed")
 			}
 		}
 
@@ -521,7 +521,7 @@ func GetRoot() unsafe.Pointer {
 func SetRoot(addr unsafe.Pointer) (err error) {
 	s := spanOfHeap(uintptr(addr))
 	if s == nil || s.memtype != isPersistent {
-		return error(errorString("Invalid address passed to SetRoot"))
+		return errorString("Invalid address passed to SetRoot")
 	}
 
 	pa := (*pArena)(unsafe.Pointer(s.pArena))

--- a/src/runtime/pmemMeta.go
+++ b/src/runtime/pmemMeta.go
@@ -78,10 +78,10 @@ func verifyMetadata() error {
 	mappedSize := pmemHeader.mappedSize
 	fsize := getFileSize(pmemInfo.fname)
 	if fsize < 0 {
-		return error(errorString("Get file size failed"))
+		return errorString("Get file size failed")
 	}
 	if fsize < int(mappedSize) {
-		return error(errorString("File was externally truncated"))
+		return errorString("File was externally truncated")
 	}
 
 	if mappedSize == pmemHeaderSize {
@@ -99,7 +99,7 @@ func verifyMetadata() error {
 		mapAddr, isPmem, err := mapFile(pmemInfo.fname, pageSize, fileCreate,
 			_DEFAULT_FMODE, totalArenaSize, nil)
 		if err != 0 {
-			return error(errorString("Arena map failed"))
+			return errorString("Arena map failed")
 		}
 		if totalArenaSize == 0 {
 			// Add the global header size to get to the first arena's metadata
@@ -109,14 +109,14 @@ func verifyMetadata() error {
 		parena := (*pArena)(unsafe.Pointer(uintptr(mapAddr) + arenaOff))
 		if parena.magic != hdrMagic || isPmem != pmemInfo.isPmem {
 			munmap(mapAddr, pageSize)
-			return error(errorString("Arena metadata mismatch"))
+			return errorString("Arena metadata mismatch")
 		}
 		totalArenaSize += parena.size
 		munmap(mapAddr, pageSize)
 	}
 
 	if totalArenaSize != mappedSize {
-		return error(errorString("Arena size mismatch"))
+		return errorString("Arena size mismatch")
 	}
 
 	return nil


### PR DESCRIPTION
Various pmem functions were typecasting errorString datatype as an error before returning to the caller. This is not required as errorString implements the error type.
