### PR TITLE
Automatic detection of eADR capability

### DIFF
--- a/src/runtime/pmemFlush.go
+++ b/src/runtime/pmemFlush.go
@@ -32,6 +32,10 @@ func flushClwb(addr, len uintptr) {
 	}
 }
 
+func flushEmpty(addr, len uintptr) {
+	// no need to flush CPU caches, typically on platforms supporting eADR
+}
+
 func fenceEmpty() {
 	// nothing to do
 }
@@ -44,6 +48,9 @@ func sfence()
 func clwb(ptr uintptr)
 func clflush(ptr uintptr)
 func clflushopt(ptr uintptr)
+
+//go:noinline
+func compilerBarrier()
 
 // msyncRange() flushes changes made to the in-core copy of a file that was
 // mapped into memory using mmap(2) back to the filesystem.

--- a/src/runtime/pmemFlush_amd64.s
+++ b/src/runtime/pmemFlush_amd64.s
@@ -16,6 +16,9 @@ TEXT runtime·clwb(SB), $0
 	BYTE $0x66; BYTE $0x0F; BYTE $0xAE; BYTE $0x33;
 	RET
 
+TEXT runtime·compilerBarrier(SB),$0
+	RET
+
 TEXT runtime·clflushopt(SB), $0
 	MOVQ 	ptr+0(FP), BX
 	// clflushopt BX

--- a/src/runtime/pmemHeap.go
+++ b/src/runtime/pmemHeap.go
@@ -178,6 +178,10 @@ func PmemInit(fname string) (unsafe.Pointer, error) {
 				or initialization is ongoing`)
 	}
 
+	// platformInit() checks if the platform supports eADR. If not, the cache
+	// flush instruction is set according to the CPU capabilities.
+	platformInit()
+
 	// Set the persistent memory file name. This will be used to map the file
 	// into memory in growPmemRegion().
 	pmemInfo.fname = fname

--- a/src/runtime/pmemStubs.go
+++ b/src/runtime/pmemStubs.go
@@ -31,3 +31,8 @@ func getFileSize(fname string) (size int) {
 	throw("Not implemented")
 	return
 }
+
+func platformInit() {
+	throw("Not implemented")
+	return
+}


### PR DESCRIPTION
Added code that checks if the platform has CPU caches in its persistence domain (eADR). If so, software does not need to issue cache flush instructions. x86 memory model also ensures writes are made globally visible in program order. Hence, rather than a store fence, a compiler barrier suffices.

In C, `asm volatile ("" ::: "memory")` suffices to insert a compiler barrier in code. But Go does not support asm statements. The compiler barrier function added in this commit `func compilerBarrier()` just contain a `RETURN` instruction and is marked `go:noinline` to prevent it being optimized out.

I wrote an [example program](https://github.com/jerrinsg/compilerTest) to verify that this works as expected. In barrier.go, If the fence function in line 20 (https://github.com/jerrinsg/compilerTest/blob/master/barrier.go#L20) is commented out, compiler combines lines 19 and 21 as a single add instruction:
```
  45833f:   48 83 c2 02             add    $0x2,%rdx
```
But with the compiler barrier, the two increment statements are executed separately:
```
        a[i] += 1
  458355:   48 8d 0d 64 3e 0a 00    lea    0xa3e64(%rip),%rcx        # 4fc1c0 <main.a>
  45835c:   48 8b 1c c1             mov    (%rcx,%rax,8),%rbx
  458360:   48 ff c3                inc    %rbx
  458363:   48 89 1c c1             mov    %rbx,(%rcx,%rax,8)
        fenceFunc()
  458367:   48 8b 15 12 81 07 00    mov    0x78112(%rip),%rdx        # 4d0480 <main.fenceFunc>
  45836e:   48 8b 1a                mov    (%rdx),%rbx
  458371:   ff d3                   callq  *%rbx
        a[i] += 1
  458373:   48 8b 04 24             mov    (%rsp),%rax
  458377:   48 8d 0d 42 3e 0a 00    lea    0xa3e42(%rip),%rcx        # 4fc1c0 <main.a>
  45837e:   48 8b 1c c1             mov    (%rcx,%rax,8),%rbx
  458382:   48 ff c3                inc    %rbx
  458385:   48 89 1c c1             mov    %rbx,(%rcx,%rax,8)
```